### PR TITLE
katip-0.8.0.0 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,7 @@ cabal.sandbox.config
 *.hp
 *.eventlog
 .stack-work/
+stack.yaml.lock
 cabal.project.local
 .HTF/
 

--- a/package.yaml
+++ b/package.yaml
@@ -6,7 +6,7 @@ extra-source-files:
 github: joneshf/katip-rollbar
 library:
   dependencies:
-    - aeson >= 1.2 && < 1.5
+    - aeson >= 1.2 && < 1.6
     - async >= 2.1 && < 2.3
     - base >= 4.7 && < 5
     - hostname >= 1.0 && < 1.1

--- a/package.yaml
+++ b/package.yaml
@@ -6,16 +6,16 @@ extra-source-files:
 github: joneshf/katip-rollbar
 library:
   dependencies:
-    - aeson >= 1.2 && < 1.3
-    - async >= 2.1 && < 2.2
+    - aeson >= 1.2 && < 1.5
+    - async >= 2.1 && < 2.3
     - base >= 4.7 && < 5
     - hostname >= 1.0 && < 1.1
     - http-client >= 0.5.10
-    - katip >= 0.5 && < 0.6
-    - rollbar-hs >= 0.2 && < 0.3
+    - katip >= 0.8 && < 0.9
+    - rollbar-hs >= 0.2 && < 0.4
     - stm-chans >= 3.0 && < 3.1
     - text >= 1.2 && < 1.3
-    - time >= 1.8 && < 1.9
+    - time >= 1.8 && < 1.10
   source-dirs: src
 license: BSD3
 maintainer: jones3.hardy@gmail.com

--- a/src/Katip/Scribes/Rollbar.hs
+++ b/src/Katip/Scribes/Rollbar.hs
@@ -31,7 +31,7 @@ import "text" Data.Text.Lazy.Builder               (toLazyText)
 import "time" Data.Time.Clock                      (UTCTime)
 import "katip" Katip
     ( LogItem
-    , Scribe(Scribe, liPush, scribeFinalizer)
+    , Scribe(Scribe, liPush, scribeFinalizer, scribePermitItem)
     , Severity(DebugS, ErrorS, InfoS, NoticeS, WarningS)
     , Verbosity
     , getEnvironment
@@ -89,13 +89,18 @@ mkRollbarScribe
 mkRollbarScribe proxy accessToken branch codeVersion manager severity verbosity = do
   queue <- newTBMQueueIO queueSize
   workers <- replicateM workerSize (async $ mkWorker proxy manager queue)
-  let liPush item = when (permitItem severity item) $
-        atomically (writeTBMQueue queue $ rollbarItem' item)
+
+  let liPush item = do
+        permitted <- (permitItem severity item)
+        when permitted $
+          atomically (writeTBMQueue queue $ rollbarItem' item)
       rollbarItem' item = rollbarItem proxy accessToken branch codeVersion verbosity item
+      scribePermitItem =
+        permitItem severity
       scribeFinalizer = do
         atomically (closeTBMQueue queue)
         for_ workers waitCatch
-  pure Scribe { liPush, scribeFinalizer }
+  pure Scribe { liPush, scribeFinalizer, scribePermitItem }
 
 rollbarItem ::
   (LogItem a, RemoveHeaders headers) =>

--- a/src/Katip/Scribes/Rollbar.hs
+++ b/src/Katip/Scribes/Rollbar.hs
@@ -91,7 +91,7 @@ mkRollbarScribe proxy accessToken branch codeVersion manager severity verbosity 
   workers <- replicateM workerSize (async $ mkWorker proxy manager queue)
 
   let liPush item = do
-        permitted <- (permitItem severity item)
+        permitted <- permitItem severity item
         when permitted $
           atomically (writeTBMQueue queue $ rollbarItem' item)
       rollbarItem' item = rollbarItem proxy accessToken branch codeVersion verbosity item

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,6 @@ packages:
 extra-deps:
     # - rollbar-hs-0.2.0.0
 - git: https://www.github.com/parsonsmatt/rollbar-hs
-  commit: 17770be71c0c1aa104b0db064c58c69384f3820a
+  commit: 01884d716d1360dc9336a8364db6657859684f0d
 
 resolver: lts-15.11

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,9 @@
-flags: {}
 packages:
 - .
+
 extra-deps:
-- rollbar-hs-0.2.0.0
-resolver: lts-10.5
+    # - rollbar-hs-0.2.0.0
+- git: https://www.github.com/parsonsmatt/rollbar-hs
+  commit: 17770be71c0c1aa104b0db064c58c69384f3820a
+
+resolver: lts-15.11


### PR DESCRIPTION
This PR updates the library to be compatible with `katip-0.8.0.0`, and bumps upper bounds for other libraries. I've tested this with the current `nightly` and it works.

You may wish to release #3 or #4 first, since they would be compatible with the other versions of `katip`. 

I'm also happy to volunteer to be a maintainer on this package as well as `rollbar-hs` :smile: 